### PR TITLE
composer.json - Switch to civicrm/gitignore fork (w/php82+ support)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         php: [7.2, 7.3, 7.4, 8.0, 8.1]
         os: [ubuntu-latest]
-        composer: [v1, v2]
+        composer: [v2]
     name: ${{ matrix.php }} - PHPUnit - Composer ${{ matrix.composer }}
     steps:
       - uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,12 @@
         }
     ],
     "require": {
-        "composer-plugin-api": "^1.1 || ^2.0",
+        "composer-plugin-api": "^2.0",
         "php": ">=7.2",
         "civicrm/gitignore": "~1.2.0"
     },
     "require-dev": {
-        "composer/composer": "~1.0 || ~2.0",
+        "composer/composer": "~2.0",
         "phpunit/phpunit": "^8.5 || ^9.5",
         "friendsofphp/php-cs-fixer": "^2.3",
         "totten/process-helper": "^1.0.1"

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "composer-plugin-api": "^1.1 || ^2.0",
         "php": ">=7.2",
-        "togos/gitignore": "~1.1.1"
+        "civicrm/gitignore": "~1.2.0"
     },
     "require-dev": {
         "composer/composer": "~1.0 || ~2.0",


### PR DESCRIPTION
`togos/gitignore` appears to be unmaintained. Switch to fork `civicrm/gitignore` which includes the patch for php82 (via @seamuslee001) along with other small cleanups.

See also:

* https://lab.civicrm.org/dev/core/-/issues/3833
* https://lab.civicrm.org/dev/core/-/issues/4919
